### PR TITLE
Add profile persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ I wrote this as a tool for my own use — especially since I like setting up fre
 - Bulk import `.ovpn` files
 - Create and manage login profiles
 - View, edit, or delete VPNs from a user-friendly interface
+- Customize the GUI with theme settings
 
 ## About
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,42 @@
+import json
+import os
+
+PROFILES_FILE = "profiles.json"
+
 profiles = {}
 selected_profile = None
 profile_selector_widget = None
+
+def load_profiles():
+    global profiles, selected_profile
+    if os.path.exists(PROFILES_FILE):
+        try:
+            with open(PROFILES_FILE, "r", encoding="utf-8") as f:
+                data = json.load(f)
+                profiles = data.get("profiles", {})
+                selected_profile = data.get("selected_profile")
+        except Exception:
+            profiles = {}
+            selected_profile = None
+    else:
+        profiles = {}
+        selected_profile = None
+
+def save_profiles():
+    data = {
+        "profiles": profiles,
+        "selected_profile": selected_profile,
+    }
+    with open(PROFILES_FILE, "w", encoding="utf-8") as f:
+        json.dump(data, f)
+
+def set_selected_profile(name):
+    global selected_profile
+    selected_profile = name
+    save_profiles()
+
+# Load profiles when module is imported
+load_profiles()
 
 def add_profile(name, username, password):
     global profiles
@@ -8,6 +44,7 @@ def add_profile(name, username, password):
     if profile_selector_widget:
         profile_selector_widget.configure(values=get_profile_names())
         profile_selector_widget.set(name)
+    save_profiles()
 
 def get_profile_names():
     return list(profiles.keys())
@@ -19,6 +56,7 @@ def delete_profile(name):
     global profiles
     if name in profiles:
         del profiles[name]
+        save_profiles()
 
 # Update profile credentials
 def update_profile(name, username=None, password=None):
@@ -27,3 +65,4 @@ def update_profile(name, username=None, password=None):
             profiles[name]["username"] = username
         if password is not None:
             profiles[name]["password"] = password
+        save_profiles()

--- a/gui.py
+++ b/gui.py
@@ -2,7 +2,41 @@ import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import os
 from vpn_controller import *
-from config import profiles, selected_profile, add_profile, get_profile_names, get_profile, profile_selector_widget
+from config import profiles, selected_profile, add_profile, get_profile_names, get_profile, profile_selector_widget, set_selected_profile, load_profiles
+import theme_config
+
+# ensure stored profiles are loaded before building UI
+load_profiles()
+theme_config.load_themes()
+
+def apply_theme(root):
+    theme = theme_config.themes.get(theme_config.active_theme)
+    if not theme:
+        return
+    bg = theme_config.to_hex(theme['bg'])
+    fg = theme_config.to_hex(theme['fg'])
+    panel_bg = theme_config.to_hex(theme.get('panel_bg', theme['bg']))
+    button_bg = theme_config.to_hex(theme.get('button_bg', theme['bg']))
+    style = ttk.Style()
+    style.configure('TFrame', background=panel_bg)
+    style.configure('TLabel', background=panel_bg, foreground=fg)
+    style.configure('TButton', background=button_bg, foreground=fg)
+    style.configure('TCombobox', fieldbackground=panel_bg, background=panel_bg, foreground=fg)
+    root.configure(bg=bg)
+
+    def recurse(w):
+        for child in w.winfo_children():
+            if isinstance(child, tk.Frame):
+                child.configure(bg=panel_bg)
+            elif isinstance(child, tk.Label):
+                child.configure(bg=panel_bg, fg=fg)
+            elif isinstance(child, tk.Button):
+                child.configure(bg=button_bg, fg=fg, activebackground=button_bg)
+            elif isinstance(child, tk.Entry):
+                child.configure(bg=panel_bg, fg=fg, insertbackground=fg)
+            recurse(child)
+
+    recurse(root)
 
 # tab for displaying vpns
 def add_vpn_tab(notebook):
@@ -13,7 +47,7 @@ def add_vpn_tab(notebook):
     left_frame = tk.Frame(vpn_tab)
     left_frame.pack(side="left", fill="both", expand=True, padx=5, pady=5)
 
-    right_frame = tk.Frame(vpn_tab, bg="#f0f0f0")
+    right_frame = tk.Frame(vpn_tab)
     right_frame.pack(side="right", fill="both", expand=True, padx=5, pady=5)
 
     # Left side: Treeview
@@ -37,10 +71,11 @@ def add_vpn_tab(notebook):
 
     profile_selector = ttk.Combobox(right_frame, state="readonly", values=get_profile_names())
     profile_selector.pack(pady=2)
+    if selected_profile:
+        profile_selector.set(selected_profile)
 
     def update_selected_profile(event):
-        global selected_profile
-        selected_profile = profile_selector.get()
+        set_selected_profile(profile_selector.get())
 
     profile_selector.bind("<<ComboboxSelected>>", update_selected_profile)
 
@@ -114,6 +149,7 @@ def add_profile_tab(notebook):
             return
         add_profile(name, user, pwd)
         selected_profile_var.set(name)
+        set_selected_profile(name)
         refresh_profile_dropdown()
         messagebox.showinfo("Saved", f"Profile '{name}' saved successfully.")
 
@@ -122,10 +158,22 @@ def add_profile_tab(notebook):
         menu.delete(0, "end")
         for name in get_profile_names():
             menu.add_command(label=name, command=tk._setit(selected_profile_var, name))
+        if selected_profile:
+            selected_profile_var.set(selected_profile)
+        elif get_profile_names():
+            selected_profile_var.set(get_profile_names()[0])
+        if selected_profile_var.get():
+            set_selected_profile(selected_profile_var.get())
+
+    def option_selected(value):
+        set_selected_profile(value)
 
     tk.Label(profile_tab, text="Select Profile:").pack(pady=5)
-    profile_menu = tk.OptionMenu(profile_tab, selected_profile_var, "")
+    profile_menu = tk.OptionMenu(profile_tab, selected_profile_var, "", command=option_selected)
     profile_menu.pack(pady=5)
+
+    # populate dropdown with stored profiles
+    refresh_profile_dropdown()
 
     tk.Label(profile_tab, text="Profile Name:").pack(pady=2)
     name_entry = tk.Entry(profile_tab)
@@ -142,10 +190,26 @@ def add_profile_tab(notebook):
     tk.Button(profile_tab, text="Save Profile", command=save_profile).pack(pady=10)
 
 # tab for system settings
-def add_settings_tab(notebook):
+def add_settings_tab(notebook, root):
     settings_tab = tk.Frame(notebook)
     notebook.add(settings_tab, text="System Settings")
-    tk.Label(settings_tab, text="This is the Settings tab").pack(pady=20)
+
+    tk.Label(settings_tab, text="Select Theme:").pack(pady=5)
+    theme_var = tk.StringVar(value=theme_config.active_theme)
+    theme_dropdown = ttk.Combobox(
+        settings_tab,
+        state="readonly",
+        values=list(theme_config.themes.keys()),
+        textvariable=theme_var,
+    )
+    theme_dropdown.pack(pady=5)
+
+    def apply_selected(event=None):
+        theme_config.set_active_theme(theme_var.get())
+        apply_theme(root)
+
+    theme_dropdown.bind("<<ComboboxSelected>>", apply_selected)
+    tk.Button(settings_tab, text="Apply", command=apply_selected).pack(pady=10)
 
 def build_tabs(root):
     notebook = ttk.Notebook(root)
@@ -153,4 +217,5 @@ def build_tabs(root):
 
     add_vpn_tab(notebook)
     add_profile_tab(notebook)
-    add_settings_tab(notebook)
+    add_settings_tab(notebook, root)
+    apply_theme(root)

--- a/theme_config.py
+++ b/theme_config.py
@@ -1,0 +1,79 @@
+import configparser
+import os
+
+THEMES_FILE = "themes.ini"
+
+DEFAULT_THEMES = {
+    "light": {
+        "bg": "255,255,255",
+        "fg": "0,0,0",
+        "panel_bg": "240,240,240",
+        "button_bg": "230,230,230",
+    },
+    "dark": {
+        "bg": "45,45,45",
+        "fg": "220,220,220",
+        "panel_bg": "55,55,55",
+        "button_bg": "70,70,70",
+    },
+}
+
+themes = {}
+active_theme = "light"
+
+def _rgb_to_tuple(s):
+    return tuple(int(x) for x in s.split(','))
+
+def _tuple_to_rgb(t):
+    return ','.join(str(x) for x in t)
+
+def _write_default():
+    config = configparser.ConfigParser()
+    config["DEFAULT"] = {"active_theme": "light"}
+    for name, vals in DEFAULT_THEMES.items():
+        config[name] = vals
+    with open(THEMES_FILE, "w", encoding="utf-8") as f:
+        config.write(f)
+
+def load_themes():
+    global themes, active_theme
+    if not os.path.exists(THEMES_FILE):
+        _write_default()
+    cfg = configparser.ConfigParser()
+    cfg.read(THEMES_FILE)
+    active_theme = cfg["DEFAULT"].get("active_theme", "light")
+    themes = {}
+    for section in cfg.sections():
+        if section == "DEFAULT":
+            continue
+        defaults = DEFAULT_THEMES.get(section, DEFAULT_THEMES.get("light"))
+        bg = _rgb_to_tuple(cfg[section].get("bg", defaults["bg"]))
+        fg = _rgb_to_tuple(cfg[section].get("fg", defaults["fg"]))
+        panel_bg = _rgb_to_tuple(cfg[section].get("panel_bg", defaults.get("panel_bg", defaults["bg"])))
+        button_bg = _rgb_to_tuple(cfg[section].get("button_bg", defaults.get("button_bg", defaults["bg"])))
+        themes[section] = {
+            "bg": bg,
+            "fg": fg,
+            "panel_bg": panel_bg,
+            "button_bg": button_bg,
+        }
+
+def save_themes():
+    cfg = configparser.ConfigParser()
+    cfg["DEFAULT"] = {"active_theme": active_theme}
+    for name, vals in themes.items():
+        cfg[name] = {k: _tuple_to_rgb(v) for k, v in vals.items()}
+    with open(THEMES_FILE, "w", encoding="utf-8") as f:
+        cfg.write(f)
+
+def set_active_theme(name):
+    global active_theme
+    if name in themes:
+        active_theme = name
+        save_themes()
+
+def to_hex(rgb_tuple):
+    return "#%02x%02x%02x" % rgb_tuple
+
+# load at import
+load_themes()

--- a/themes.ini
+++ b/themes.ini
@@ -1,0 +1,14 @@
+[DEFAULT]
+active_theme = light
+
+[light]
+bg = 255,255,255
+fg = 0,0,0
+panel_bg = 240,240,240
+button_bg = 230,230,230
+
+[dark]
+bg = 45,45,45
+fg = 220,220,220
+panel_bg = 55,55,55
+button_bg = 70,70,70


### PR DESCRIPTION
## Summary
- persist profiles by storing them in `profiles.json`
- load stored data when the app starts
- sync selected profile changes to disk
- enable theme customization via `themes.ini`
- add a System Settings tab to select the active theme
- expand themes with additional variables and update GUI styling

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_684828870284832592de1fcdc8090be8