### PR TITLE
Fix theme application error with ttk widgets

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -32,7 +32,9 @@ def apply_theme(root):
                 child.configure(bg=panel_bg, fg=fg)
             elif isinstance(child, tk.Button):
                 child.configure(bg=button_bg, fg=fg, activebackground=button_bg)
-            elif isinstance(child, tk.Entry):
+            elif isinstance(child, tk.Entry) and not isinstance(child, ttk.Entry):
+                # Skip ttk widgets like Combobox which inherit from tk.Entry but
+                # don't support the classic Tk options
                 child.configure(bg=panel_bg, fg=fg, insertbackground=fg)
             recurse(child)
 


### PR DESCRIPTION
## Summary
- skip ttk widgets when applying Entry styling to avoid '-bg' error

## Testing
- `python3 -m py_compile gui.py theme_config.py vpn_controller.py config.py main.py`

------
https://chatgpt.com/codex/tasks/task_e_68483d09f5248325a189d7d815722c9f