### PR TITLE
Add VPN editing window

### DIFF
--- a/edit_vpn_gui.py
+++ b/edit_vpn_gui.py
@@ -1,0 +1,112 @@
+import tkinter as tk
+from tkinter import ttk, messagebox
+from config import get_profile_names, get_profile, selected_profile
+from vpn_controller import get_all_vpn_names, update_vpn_credentials
+import theme_config
+
+
+def apply_theme(root):
+    theme = theme_config.themes.get(theme_config.active_theme)
+    if not theme:
+        return
+    bg = theme_config.to_hex(theme["bg"])
+    fg = theme_config.to_hex(theme["fg"])
+    panel_bg = theme_config.to_hex(theme.get("panel_bg", theme["bg"]))
+    button_bg = theme_config.to_hex(theme.get("button_bg", theme["bg"]))
+    dropdown_bg = theme_config.to_hex(theme.get("dropdown_bg", panel_bg))
+    dropdown_fg = theme_config.to_hex(theme.get("dropdown_fg", fg))
+
+    style = ttk.Style()
+    style.configure("TFrame", background=panel_bg)
+    style.configure("TLabel", background=panel_bg, foreground=fg)
+    style.configure("TButton", background=button_bg, foreground=fg)
+    style.configure(
+        "TCombobox",
+        fieldbackground=dropdown_bg,
+        background=dropdown_bg,
+        foreground=dropdown_fg,
+        selectbackground=dropdown_bg,
+        selectforeground=dropdown_fg,
+    )
+    style.map(
+        "TCombobox",
+        fieldbackground=[("readonly", dropdown_bg)],
+        selectbackground=[("readonly", dropdown_bg)],
+        selectforeground=[("readonly", dropdown_fg)],
+        background=[("readonly", dropdown_bg)],
+        foreground=[("readonly", dropdown_fg)],
+    )
+    root.configure(bg=bg)
+
+    def recurse(w):
+        for child in w.winfo_children():
+            if isinstance(child, tk.Frame):
+                child.configure(bg=panel_bg)
+            elif isinstance(child, tk.Label):
+                child.configure(bg=panel_bg, fg=fg)
+            elif isinstance(child, tk.Button):
+                child.configure(bg=button_bg, fg=fg, activebackground=button_bg)
+            elif isinstance(child, tk.Entry) and not isinstance(child, ttk.Entry):
+                child.configure(bg=panel_bg, fg=fg, insertbackground=fg)
+            recurse(child)
+
+    recurse(root)
+
+
+def open_edit_vpn_window(parent=None):
+    win = tk.Toplevel(parent) if parent else tk.Toplevel()
+    win.title("Edit VPN")
+    win.geometry("400x300")
+    win.resizable(False, False)
+
+    tk.Label(win, text="Select VPN:").pack(pady=(10, 2))
+    vpn_var = tk.StringVar()
+    vpn_dropdown = ttk.Combobox(win, state="readonly", values=get_all_vpn_names(), textvariable=vpn_var)
+    vpn_dropdown.pack(pady=2)
+
+    tk.Label(win, text="Profile:").pack(pady=(10, 2))
+    profile_var = tk.StringVar(value=selected_profile if selected_profile else "")
+    profile_dropdown = ttk.Combobox(win, state="readonly", values=get_profile_names(), textvariable=profile_var)
+    profile_dropdown.pack(pady=2)
+
+    tk.Label(win, text="Username:").pack(pady=(10, 2))
+    user_entry = tk.Entry(win)
+    user_entry.pack(pady=2)
+
+    tk.Label(win, text="Password:").pack(pady=(10, 2))
+    pass_entry = tk.Entry(win, show="*")
+    pass_entry.pack(pady=2)
+
+    def load_profile(event=None):
+        prof = get_profile(profile_var.get())
+        if prof:
+            user_entry.delete(0, tk.END)
+            user_entry.insert(0, prof["username"])
+            pass_entry.delete(0, tk.END)
+            pass_entry.insert(0, prof["password"])
+
+    profile_dropdown.bind("<<ComboboxSelected>>", load_profile)
+    if selected_profile:
+        load_profile()
+
+    def save():
+        name = vpn_var.get()
+        if not name:
+            messagebox.showwarning("Input Error", "Please select a VPN")
+            return
+        username = user_entry.get()
+        password = pass_entry.get()
+        if not username or not password:
+            messagebox.showwarning("Input Error", "Username and password required")
+            return
+        update_vpn_credentials(name, username, password)
+        messagebox.showinfo("Saved", f"Updated VPN '{name}'.")
+        win.destroy()
+
+    tk.Button(win, text="Save", command=save).pack(pady=10)
+
+    apply_theme(win)
+    win.grab_set()
+    win.transient(parent)
+    win.wait_window()
+

--- a/gui.py
+++ b/gui.py
@@ -2,6 +2,7 @@ import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
 import os
 from vpn_controller import *
+from edit_vpn_gui import open_edit_vpn_window
 from config import profiles, selected_profile, add_profile, get_profile_names, get_profile, profile_selector_widget, set_selected_profile, load_profiles
 import theme_config
 
@@ -169,6 +170,7 @@ def add_vpn_tab(notebook):
 
     tk.Button(right_frame, text="Import VPN", command=import_vpn_action).pack(pady=10)
     tk.Button(right_frame, text="Bulk Import Folder", command=bulk_import_action).pack(pady=10)
+    tk.Button(right_frame, text="Edit VPN", command=lambda: open_edit_vpn_window(vpn_tab.winfo_toplevel())).pack(pady=10)
     tk.Button(right_frame, text="Delete Selected VPN", command=lambda: delete_selected(tree, refresh_tree)).pack(pady=10)
     tk.Button(right_frame, text="Delete ALL VPNs", command=delete_all_action).pack(pady=10)
     tk.Button(right_frame, text="Refresh List", command=refresh_tree).pack(pady=10)

--- a/main.py
+++ b/main.py
@@ -6,7 +6,8 @@ from gui import build_tabs
 def main():
     root = tk.Tk()
     root.title("VPN Manager")
-    root.geometry("600x400")
+    root.geometry("600x500")
+    root.resizable(False, False)
 
     build_tabs(root)
 

--- a/vpn_controller.py
+++ b/vpn_controller.py
@@ -35,3 +35,10 @@ def disconnect_vpn(name):
 def set_autoconnect(name, enabled=True):
     flag = "yes" if enabled else "no"
     subprocess.run(["nmcli", "connection", "modify", name, "connection.autoconnect", flag])
+
+
+def update_vpn_credentials(name, username, password):
+    """Update an existing VPN connection with new credentials."""
+    subprocess.run(["nmcli", "connection", "modify", name, "vpn.user-name", username])
+    subprocess.run(["nmcli", "connection", "modify", name, "+vpn.data", "password-flags=0"])
+    subprocess.run(["nmcli", "connection", "modify", name, "vpn.secrets", f"password={password}"])


### PR DESCRIPTION
## Summary
- allow window to be taller and non-resizable
- provide Edit VPN button for editing credentials
- implement Edit VPN window with themed UI
- add helper to update VPN credentials

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68791d5a531483258af713e55e491c2d